### PR TITLE
feat: improve Anthropic structured response handling

### DIFF
--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -13,7 +13,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@brandpack/core": "workspace:*",
@@ -22,7 +23,8 @@
   },
   "devDependencies": {
     "typescript": "^5.3.3",
-    "@types/node": "^20.10.6"
+    "@types/node": "^20.10.6",
+    "vitest": "^1.6.0"
   }
 }
 

--- a/packages/adapters/src/anthropic.test.ts
+++ b/packages/adapters/src/anthropic.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { AnthropicAdapter } from './anthropic';
+import type { LLMSpec } from '@brandpack/core';
+import { AdapterError } from '@brandpack/core';
+
+vi.mock('@anthropic-ai/sdk', () => {
+  return {
+    default: vi.fn().mockImplementation(() => ({
+      messages: {
+        create: vi.fn()
+      }
+    }))
+  };
+});
+
+const createAdapter = () => new AnthropicAdapter({ apiKey: 'test-key', model: 'claude-3-haiku-20240307' });
+
+describe('AnthropicAdapter mapSpecToAnthropic', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sets json response_format for json specs', () => {
+    const adapter = createAdapter();
+    const spec: LLMSpec = {
+      task_id: 'json_task',
+      system_prompt: 'system',
+      user_prompt: 'user',
+      response_format: 'json',
+      constraints: {}
+    };
+
+    const params = (adapter as any).mapSpecToAnthropic(spec);
+    expect((params as any).response_format).toEqual({ type: 'json' });
+  });
+
+  it('sets json schema response_format for structured specs', () => {
+    const adapter = createAdapter();
+    const spec: LLMSpec = {
+      task_id: 'structured_task',
+      system_prompt: 'system',
+      user_prompt: 'user',
+      response_format: 'structured',
+      schema: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' }
+        },
+        required: ['name']
+      },
+      constraints: {}
+    };
+
+    const params = (adapter as any).mapSpecToAnthropic(spec);
+    expect((params as any).response_format).toEqual({
+      type: 'json_schema',
+      json_schema: {
+        name: 'structured_task',
+        schema: spec.schema
+      }
+    });
+  });
+});
+
+describe('AnthropicAdapter extractOutputs', () => {
+  const baseResponse = {
+    id: 'msg_1',
+    type: 'message',
+    role: 'assistant',
+    model: 'claude-3-haiku-20240307',
+    stop_reason: 'end_turn',
+    stop_sequence: null,
+    usage: { input_tokens: 10, output_tokens: 20 }
+  } as const;
+
+  it('returns structured payload from tool blocks', () => {
+    const adapter = createAdapter();
+    const response = {
+      ...baseResponse,
+      content: [
+        {
+          type: 'tool_use',
+          id: 'tool_1',
+          name: 'json_schema_response',
+          input: {
+            summary: 'ok'
+          }
+        }
+      ]
+    } as any;
+
+    const outputs = (adapter as any).extractOutputs(response, 'structured');
+    expect(outputs).toEqual(['{"summary":"ok"}']);
+  });
+
+  it('throws AdapterError when structured payload is malformed', () => {
+    const adapter = createAdapter();
+    const response = {
+      ...baseResponse,
+      content: [
+        {
+          type: 'text',
+          text: 'not json'
+        }
+      ]
+    } as any;
+
+    expect(() => (adapter as any).extractOutputs(response, 'structured')).toThrow(AdapterError);
+  });
+});


### PR DESCRIPTION
## Summary
- set the Anthropic adapter response_format field for json and structured specs
- parse Anthropic responses for JSON outputs, including tool blocks, with schema validation
- add adapter tests exercising structured payload success and malformed error cases

## Testing
- npm run test --workspace packages/adapters *(fails: vitest not installed in workspace environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e66fdda5e88324a40f2a7632e5210f