### PR TITLE
refactor: disambiguate adapter image types

### DIFF
--- a/packages/adapters/src/noop.ts
+++ b/packages/adapters/src/noop.ts
@@ -10,9 +10,9 @@ import type {
   LLMSpec,
   AdapterResponse,
   ImageAdapter,
-  ImageBrief,
+  AdapterImageBrief,
   ImageConfig,
-  ImageResult
+  AdapterImageResult
 } from '@brandpack/core';
 
 /**
@@ -188,7 +188,10 @@ export class NoopImageAdapter implements ImageAdapter {
   /**
    * Generate mock image
    */
-  async generate(brief: ImageBrief, config: ImageConfig): Promise<ImageResult> {
+  async generate(
+    brief: AdapterImageBrief,
+    config: ImageConfig
+  ): Promise<AdapterImageResult> {
     const startTime = Date.now();
     
     // Simulate generation delay

--- a/packages/adapters/src/router.ts
+++ b/packages/adapters/src/router.ts
@@ -8,9 +8,9 @@
 import type {
   LLMSpec,
   AdapterResponse,
-  ImageBrief,
+  AdapterImageBrief,
   ImageConfig,
-  ImageResult
+  AdapterImageResult
 } from '@brandpack/core';
 import { AdapterError, AdapterErrorCode } from '@brandpack/core';
 import { llmRegistry, imageRegistry } from './registry';
@@ -143,10 +143,10 @@ export async function routeSpecBatch(
  * Route an image generation request
  */
 export async function routeImageGeneration(
-  brief: ImageBrief,
+  brief: AdapterImageBrief,
   config: ImageConfig,
   options: RouteOptions = {}
-): Promise<ImageResult> {
+): Promise<AdapterImageResult> {
   const targetProvider = options.provider || config.provider;
   
   // Get adapter from registry
@@ -213,10 +213,10 @@ export async function routeImageGeneration(
  * Route multiple image generations in parallel
  */
 export async function routeImageBatch(
-  briefs: ImageBrief[],
+  briefs: AdapterImageBrief[],
   config: ImageConfig,
   options: RouteOptions = {}
-): Promise<ImageResult[]> {
+): Promise<AdapterImageResult[]> {
   return Promise.all(
     briefs.map(brief => routeImageGeneration(brief, config, options))
   );

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -14,9 +14,9 @@ export type {
   AdapterResponse,
   TokenUsage,
   ImageAdapter,
-  ImageBrief,
+  ImageBrief as AdapterImageBrief,
   ImageConfig,
-  ImageResult,
+  ImageResult as AdapterImageResult,
   ProviderPricing
 } from './adapter';
 export { AdapterError, AdapterErrorCode, calculateCost } from './adapter';


### PR DESCRIPTION
## Summary
- alias the adapter-layer image brief/result exports to unique AdapterImage* names
- update adapter router and noop implementations to consume the new aliases
- confirmed remaining ImageBrief/ImageResult imports reference the intended layer via `rg`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e66fdbdb8c83249aba911e67cf3e0a