### PR TITLE
Fix codex app errors

### DIFF
--- a/packages/core/src/kernel/index.ts
+++ b/packages/core/src/kernel/index.ts
@@ -1,0 +1,8 @@
+export {
+  compressKernel,
+  type KernelInput,
+  type KernelPayload,
+  type KernelSource,
+  type KernelStore,
+  type KernelRecord,
+} from './compressor';

--- a/packages/core/src/ranker/index.ts
+++ b/packages/core/src/ranker/index.ts
@@ -1,0 +1,13 @@
+export {
+  scoreCandidates,
+  type RankCandidate,
+  type RankedCandidate,
+  type ScoreConfig,
+} from './scorer';
+
+export {
+  detectSlop,
+  applySlopPenalty,
+  type SlopCheckOptions,
+  type SlopFlag,
+} from './slop';


### PR DESCRIPTION
Create missing `index.ts` files in `kernel` and `ranker` directories to resolve module import errors.

The `packages/core/src/index.ts` was attempting to import from `./kernel` and `./ranker`, but the corresponding `index.ts` files were absent, leading to module resolution failures. These changes introduce the necessary barrel files to correctly export the modules.

---
<a href="https://cursor.com/background-agent?bcId=bc-f96b93ae-2da8-45bc-8add-7a63729d94bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f96b93ae-2da8-45bc-8add-7a63729d94bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

